### PR TITLE
[exporter] disable health check for gocti

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -62,7 +62,7 @@ dockers:
       - "--platform=linux/arm64"
 
 archives:
-  - format: tar.gz
+  - formats: [ 'tar.gz ']
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.3.0] - 2025-01-27
+
+### Changed
+
+- Disable health check when creating gocti client
+
 ## [v0.2.0] - 2025-01-24
 
 ### Changed

--- a/main.go
+++ b/main.go
@@ -92,7 +92,6 @@ func run(env envConfig) error {
 
 	opencti, err := gocti.NewOpenCTIAPIClient(
 		env.OpenctiURL, env.OpenctiToken,
-		gocti.WithHealthCheck(),
 		gocti.WithLogLevel(env.LogLevel),
 	)
 	if err != nil {


### PR DESCRIPTION
With the initial health check, the gocti client can't be instantiated if the opencti instance is down.